### PR TITLE
feat(ui): tambah mode relokasi dan pelaporan data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,24 @@ Nomor versi mengikuti Semantic Versioning: `MAJOR.MINOR.PATCH`.
 ### Added
 - Tautan berbagi berversi untuk memulihkan wilayah perbandingan, profil
   rumah tangga, pendapatan/cicilan, mode warna, dan filter legenda.
+- Mode relokasi yang memisahkan gaji asal dari biaya kota tujuan, termasuk
+  status asal yang persisten, provenance UMK asal, dan perbandingan beberapa
+  kota tujuan.
+- CTA koreksi per wilayah menuju form Airtable yang menjelaskan antrean manual
+  dan tidak mengubah dataset secara otomatis.
+- Hitungan penggunaan agregat yang hanya disimpan lokal di browser; tidak ada
+  URL, kode wilayah, nilai asumsi, atau angka finansial yang dikirim.
 - Tombol Bagikan yang memakai share sheet perangkat atau menyalin tautan,
   lengkap dengan penjelasan privasi untuk angka finansial yang ikut dibagikan.
 
 ### Changed
 - Roadmap disusun ulang menjadi Now/Next/Later dan diselaraskan dengan status
-  AP-02, AP-03, serta fondasi AP-07 yang sudah tersedia.
+  AP-02, AP-03, AP-06, dan AP-07 yang sudah tersedia; audit baseline AP-05
+  dicatat di `docs/audit-wilayah-2026-09.md`.
+- Format share URL naik ke v2 untuk membawa asal relokasi, sementara decoder
+  tetap kompatibel dengan URL v1.
+- Preferensi tampilan dan wilayah aktif dinormalisasi sebelum dibaca dari
+  localStorage agar state lama atau input yang diedit manual gagal dengan aman.
 
 ## [0.1.0] - 2026-09-03
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,8 +35,12 @@ kerja kecil, sedang, dan besar.
   Jendela detail mencantumkan asal setiap angka.
 - Dataset JSON berversi `public/data/v2026.1/` dengan manifest, skema Zod,
   pemeriksaan integritas, dan catatan perubahan data.
-- Tautan berbagi berversi yang memulihkan wilayah tersemat/terpilih, asumsi
-  aktif, mode warna, dan filter legenda (fondasi AP-07; belum dirilis).
+- Tautan berbagi v2 yang memulihkan wilayah tersemat/terpilih, asumsi aktif,
+  mode warna, filter legenda, dan opsi gaji asal relokasi. Decoder tetap
+  membaca tautan v1.
+- CTA koreksi yang kontekstual di detail wilayah, dengan antrean manual dan
+  tanpa perubahan dataset otomatis; hitungan journey agregat hanya disimpan
+  lokal di browser (tanpa URL, kode wilayah, atau nilai finansial).
 - Navigasi keyboard, label `aria`, dan kontras AA.
 - Data upah 2026 untuk 514 wilayah berlabel `official`, serta 514×10 nilai
   biaya berlabel `estimate`, dengan keterangan sumber sesuai asalnya.
@@ -48,9 +52,9 @@ kerja kecil, sedang, dan besar.
 
 - Peta dasar offline masih berupa latar polos. PMTiles yang dihosting sendiri
   belum tersedia.
-- Pemisahan eksplisit "gaji asal" dan "biaya hidup tujuan", embed, ekspor
-  CSV/PNG, PWA, data lintas tahun, detail kecamatan, antrean koreksi publik,
-  API publik, E2E Playwright, dan Lighthouse CI masih dalam rencana.
+- Embed, ekspor CSV/PNG, PWA, data lintas tahun, detail kecamatan, antrean
+  koreksi publik yang operasional, API publik, E2E Playwright, dan Lighthouse
+  CI masih dalam rencana.
 
 ---
 
@@ -94,26 +98,26 @@ laporan nantinya memakai agent terjadwal di luar situs. Keputusan 2 September
 
 | Status | Jumlah | Item |
 | --- | ---: | --- |
-| Selesai | 2 | AP-02, AP-03 |
-| Berjalan/sebagian | 3 | AP-01, AP-04, AP-07 |
-| Belum dimulai di fase Now | 2 | AP-05, AP-06 |
+| Selesai | 4 | AP-02, AP-03, AP-06, AP-07 |
+| Berjalan/sebagian | 3 | AP-01, AP-04, AP-05 |
+| Belum dimulai di fase Now | 0 | — |
 
 Risiko terbesar tetap kualitas estimasi wilayah yang diperdebatkan (AP-05)
-dan kapasitas moderasi laporan (AP-04). Fondasi berbagi AP-07 tidak bergantung
-lagi pada migrasi data karena AP-02 sudah selesai, tetapi perlu keputusan UX
-tentang asal gaji versus kota tujuan sebelum dianggap lengkap.
+dan kapasitas moderasi laporan (AP-04). AP-07 sudah memiliki model asal →
+tujuan serta kompatibilitas pembacaan v1; AP-06 sengaja hanya menyimpan hitungan
+agregat lokal, sehingga belum menyediakan analitik lintas pengguna.
 
 ### Now — September–Oktober 2026
 
 | ID | Pekerjaan | Yang perlu dilakukan | Status | Prioritas |
 | --- | --- | --- | --- | --- |
-| AP-01 | Penjelasan metode dan batasan | Tampilkan metode dekat peta dan di jendela detail. Jelaskan asumsi awal 1 orang, arti tingkat keterjangkauan, serta UMK sebagai acuan resmi, bukan gaji aktual. | 🟡 Bagian utama ✅: catatan di panel Tentang dan jendela detail; `source`/`asOf`/`confidence` sudah tampil. Pencatatan penggunaan masih menunggu AP-06. | P0 · S |
+| AP-01 | Penjelasan metode dan batasan | Tampilkan metode dekat peta dan di jendela detail. Jelaskan asumsi awal 1 orang, arti tingkat keterjangkauan, serta UMK sebagai acuan resmi, bukan gaji aktual. | 🟡 Bagian utama ✅: catatan di panel Tentang dan jendela detail; `source`/`asOf`/`confidence` sudah tampil. Hitungan penggunaan agregat lokal tersedia lewat AP-06; telemetry lintas pengguna belum digunakan. | P0 · S |
 | AP-02 | Versi dataset dan pemeriksaan data | Gunakan skema Zod dan CI untuk menolak data tidak valid sebelum menerima koreksi komunitas. Setelah itu, pindahkan dataset ke file JSON dengan versi dan catatan perubahan. | ✅ Pemeriksaan Zod + integritas join di CI (`src/data/schema.ts`, `dataset.test.ts`, kini membaca file yang di-ship). Dataset pindah ke JSON berversi `public/data/v2026.1/` dengan `manifest.json` dan catatan perubahan `public/data/CHANGELOG.md`; aplikasi memuatnya lewat fetch runtime (`src/data/loader.ts`). | P0 · M |
 | AP-03 | Personalisasi rumah tangga v1.1 | Tambahkan jumlah anak dan isian cicilan/KPR pada kontrol pendapatan dan 2 upah yang sudah ada. Tampilkan profil aktif dan tombol reset. | ✅ Stepper jumlah anak (0–5, berlaku juga untuk single) dan isian cicilan KPR yang menggantikan estimasi hunian; profil aktif tampil di header drawer dan chip perbandingan, tombol reset sudah ada. Unit test mencakup anak dan cicilan, termasuk menjaga angka profil Keluarga v0.1 tetap identik. | P0 · M |
-| AP-04 | Form koreksi per wilayah | Buat form Airtable "Laporkan angka ini" dengan wilayah, kategori, nilai lama/usulan, periode, jenis bukti, sumber, dan kontak opsional. Laporan masuk ke antrean pemeriksaan manual (`Status=New`), tanpa mengubah dataset otomatis. | 🟡 Form dan tautan ✅; antrean pemeriksaan manual serta proses penerimaan masih ❌ (skema ada di [panduan kanal masukan](docs/feedback-channels.md); template GitHub ✅). | P0 · M |
-| AP-05 | Audit wilayah yang diperdebatkan | Periksa Kep. Meranti, Samosir, Bandung, serta biaya transportasi/logistik dan kesehatan. Bandingkan hasil model dengan laporan lokal, lalu catat keputusan tiap kasus. | ❌ | P0 · S/M |
-| AP-06 | Kemudahan menemukan dan memakai fitur | Uji ulang Pendapatan sendiri, filter tingkat keterjangkauan, mode gelap, dan legenda di ponsel serta lewat keyboard. Perjelas tombol tindakan dan catat penggunaan tanpa data pribadi. | ❌ | P1 · S |
-| AP-07 | Perbandingan dan berbagi hasil untuk relokasi | Bagikan wilayah, asumsi, mode warna, dan filter lewat URL berversi; lalu pisahkan gaji asal dari biaya kota tujuan dan tambahkan affordance berbagi di panel hasil. | 🟡 Fondasi URL + tombol Bagikan + sanitasi input + uji round-trip ✅. Model eksplisit Kota A → Kota B dan kompatibilitas lintas versi berikutnya masih ❌. | P0 · M |
+| AP-04 | Form koreksi per wilayah | Buat form Airtable "Laporkan angka ini" dengan wilayah, kategori, nilai lama/usulan, periode, jenis bukti, sumber, dan kontak opsional. Laporan masuk ke antrean pemeriksaan manual (`Status=New`), tanpa mengubah dataset otomatis. | 🟡 Form, CTA kontekstual, dan skema antrean manual ✅; pemeriksaan laporan nyata serta proses penerimaan dataset masih ❌ (lihat [panduan kanal masukan](docs/feedback-channels.md); template GitHub ✅). | P0 · M |
+| AP-05 | Audit wilayah yang diperdebatkan | Periksa Kep. Meranti, Samosir, Bandung, serta biaya transportasi/logistik dan kesehatan. Bandingkan hasil model dengan laporan lokal, lalu catat keputusan tiap kasus. | 🟡 Baseline reproduktif untuk Meranti, Samosir, Bandung, transportasi, dan kesehatan sudah dicatat di [audit wilayah September 2026](docs/audit-wilayah-2026-09.md); bukti lokal dan keputusan perubahan data masih ❌. | P0 · S/M |
+| AP-06 | Kemudahan menemukan dan memakai fitur | Uji ulang Pendapatan sendiri, filter tingkat keterjangkauan, mode gelap, dan legenda di ponsel serta lewat keyboard. Perjelas tombol tindakan dan catat penggunaan tanpa data pribadi. | ✅ QA manual ponsel 375px + keyboard/focus trap untuk alur utama; CTA, status relokasi, filter, tema, dan legenda diberi label jelas. Hitungan event hanya agregat di localStorage. | P1 · S |
+| AP-07 | Perbandingan dan berbagi hasil untuk relokasi | Bagikan wilayah, asumsi, mode warna, dan filter lewat URL berversi; lalu pisahkan gaji asal dari biaya kota tujuan dan tambahkan affordance berbagi di panel hasil. | ✅ URL v2 membawa gaji asal dan tetap membaca v1; model Kota A → Kota B, biaya tujuan, UMK tujuan, provenance, status persisten, dan affordance relokasi sudah tersedia serta diuji round-trip. Embed tetap backlog terpisah. | P0 · M |
 
 ### Next — November–Desember 2026
 
@@ -134,10 +138,10 @@ tentang asal gaji versus kota tujuan sebelum dianggap lengkap.
 
 ### Urutan eksekusi untuk satu maintainer
 
-1. Pastikan kanal kontribusi publik tetap berfungsi: pantau form Airtable dan Discussions, lalu siapkan antrean pemeriksaan (AP-04, AP-10).
-2. Perjelas metode dan batasan (bagian utama AP-01 ✅), lalu audit Meranti, Samosir, Bandung, biaya transportasi, dan kesehatan (AP-05).
-3. Selesaikan antrean pemeriksaan (AP-04, AP-10) — file JSON dengan versi sudah ✅ (`public/data/v2026.1/` + catatan perubahan).
-4. Selesaikan model relokasi asal → tujuan dan kompatibilitas URL berikutnya (AP-07), lalu validasi alurnya bersama AP-06.
+1. Pastikan kanal kontribusi publik tetap berfungsi: pantau form Airtable dan Discussions, lalu operasionalkan antrean pemeriksaan (AP-04).
+2. Kumpulkan bukti lokal untuk audit Meranti, Samosir, Bandung, biaya transportasi, dan kesehatan; catat keputusan per kasus (AP-05).
+3. Setelah AP-04 berjalan, tindak lanjuti laporan sampai rilis dengan draft PR dan persetujuan manusia (AP-10) — file JSON berversi sudah ✅ (`public/data/v2026.1/` + catatan perubahan).
+4. Pertahankan QA aksesibilitas dan kompatibilitas URL v2/v1; pekerjaan lanjutan berikutnya adalah lapisan komunitas (AP-08) dan kepatuhan/gaji aktual (AP-09).
 
 ---
 
@@ -176,7 +180,7 @@ Nomor AP-xx merujuk ke rencana di atas.
 | --- | --- |
 | Bahasa Indonesia sebagai satu-satunya bahasa (pilihan i18n belum diperlukan) | ✅ |
 | Mode gelap dan filter legenda per tingkat keterjangkauan (diminta komunitas, tersedia sejak v0.1) | ✅ |
-| Berbagi dan menyematkan peta (pengaturan di URL; mode `<iframe>`) | 🟡 URL berversi + tombol Bagikan ✅; embed ❌ (→ AP-07) |
+| Berbagi dan menyematkan peta (pengaturan di URL; mode `<iframe>`) | 🟡 URL relokasi berversi + tombol Bagikan ✅; embed ❌ |
 | Ekspor CSV/PNG dengan sumber, `asOf`, dan catatan batasan | ❌ |
 | Profil rumah tangga dengan pilihan awal yang divalidasi lewat Susenas | 🟡 kontrol jumlah anak & cicilan KPR ✅ (AP-03); validasi pilihan awal lewat Susenas masih ❌ |
 | PWA yang bisa dipasang, menyimpan geometri dan data di cache, serta membuka kerangka aplikasi secara offline | ❌ |
@@ -187,11 +191,11 @@ Nomor AP-xx merujuk ke rencana di atas.
 | Pekerjaan | Status |
 | --- | --- |
 | Panduan dan pemeriksaan repo (CONTRIBUTING, CoC, template, CI) | ✅ |
-| Koreksi publik dan antrean pemeriksaan | ❌ (→ AP-04) |
+| Koreksi publik dan antrean pemeriksaan | 🟡 Form, CTA, dan skema antrean ✅; operasi pemeriksaan masih ❌ (→ AP-04) |
 | Tindak lanjut laporan sampai rilis beserta catatan perubahannya | ❌ (→ AP-10) |
 | Rilis data triwulanan dan halaman metode yang dibuat otomatis dari metadata | ❌ |
 | API publik read-only dengan OpenAPI | ❌ (→ AP-13) |
-| Evaluasi dampak lewat survei singkat dan analitik yang menjaga privasi | ❌ |
+| Evaluasi dampak lewat survei singkat dan analitik yang menjaga privasi | 🟡 Hitungan event agregat lokal ✅; survei dan analitik lintas pengguna ❌ |
 
 ### Tindak lanjut usulan komunitas
 

--- a/docs/audit-wilayah-2026-09.md
+++ b/docs/audit-wilayah-2026-09.md
@@ -1,0 +1,78 @@
+# Audit baseline wilayah diperdebatkan (10 September 2026)
+
+Catatan ini adalah pemeriksaan awal AP-05 terhadap dataset yang sedang di-ship,
+bukan keputusan untuk mengubah angka. Tujuannya memisahkan sinyal yang layak
+ditindaklanjuti dari data yang belum cukup kuat untuk recalibration.
+
+## Cara membaca audit
+
+Nilai di bawah diambil dari `public/data/v2026.1/` pada 10 September 2026.
+`Cakupan` memakai asumsi default aplikasi: satu orang, gaya hidup standar,
+rumah KPR, motor, dan tabungan aktif. Semua biaya yang diperiksa berlabel
+`confidence: estimate`, `asOf: 2026-08-01`, dan bersumber dari model; upah
+berlabel `official`, `asOf: 2026-01-01`.
+
+| Kode | Wilayah | UMK/UMP kotor | Total biaya default | Cakupan | Transport | Kesehatan |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| `14.10` | Kepulauan Meranti | Rp3.780.495 | Rp3.734.000 | 101,2% · Cukup | Rp288.000 | Rp165.000 |
+| `12.17` | Samosir | Rp3.228.949 | Rp3.373.000 | 95,7% · Ketat | Rp267.000 | Rp165.000 |
+| `32.04` | Bandung (kabupaten) | Rp3.972.202 | Rp4.011.000 | 99,0% · Ketat | Rp288.000 | Rp165.000 |
+| `32.73` | Kota Bandung | Rp4.737.678 | Rp5.123.000 | 92,5% · Ketat | Rp370.000 | Rp175.000 |
+
+## Temuan dan keputusan sementara
+
+### Kepulauan Meranti (`14.10`)
+
+- Ada satu laporan contoh di `docs/airtable-koreksi-data.csv` yang menyebut
+  pendapatan rumah tangga sekitar Rp2 juta dan mahalnya logistik/BBM antarpulau.
+- Narasi dataset menyebut biaya logistik laut, sementara konteks transportasi
+  menyebut becak motor, sepeda motor, dan penyeberangan antarpulau.
+- Sinyalnya relevan untuk audit transport/logistik, tetapi pengalaman satu
+  rumah tangga bukan dasar untuk mengganti baseline seluruh rumah tangga.
+
+**Keputusan:** tetap `Pending`. Minta tarif/rute dan periode yang bisa dicek,
+lalu bandingkan dengan biaya transport `Rp288.000` sebelum mengusulkan PR.
+
+### Samosir (`12.17`)
+
+- Narasi menyebut pangan lokal dan perikanan air tawar sebagai penyeimbang
+  biaya, serta ferry Danau Toba dan motor sebagai konteks mobilitas.
+- Baseline transport `Rp267.000` dan kesehatan `Rp165.000` tetap berasal dari
+  model umum; belum ada bukti lokal yang terhubung ke record kategori tersebut.
+
+**Keputusan:** tetap `Pending`. Perlu tarif ferry/angkutan yang bertanggal dan
+bukti biaya kesehatan lokal atau cakupan BPJS yang relevan.
+
+### Bandung
+
+Roadmap menyebut “Bandung”, sehingga audit memisahkan Kabupaten Bandung
+(`32.04`) dan Kota Bandung (`32.73`). Keduanya memiliki konteks berbeda:
+
+- Kabupaten Bandung: transport `Rp288.000`, kesehatan `Rp165.000`, dan narasi
+  menyebut angkot Soreang–Banjaran–Baleendah serta feeder Trans Metro Pasundan.
+- Kota Bandung: transport `Rp370.000`, kesehatan `Rp175.000`, dan narasi
+  menyebut TMB, Trans Metro Pasundan, kereta feeder, angkot, serta ojol.
+
+**Keputusan:** tetap `Pending`. Jangan menyamakan dua wilayah atau mengganti
+baseline dari narasi saja; kumpulkan tarif rute dan sumber biaya kesehatan
+yang sesuai dengan masing-masing kode.
+
+## Gap lintas kasus
+
+- Empat record biaya transport memakai pola sumber model yang sama; perbedaan
+  nilainya belum disertai rincian input lokal yang dapat diaudit dari aplikasi.
+- Empat record kesehatan memakai estimasi BPJS/biaya dasar, bukan tagihan atau
+  survei primer per kabupaten/kota. Ini cukup untuk label `estimate`, belum
+  cukup untuk menaikkan confidence atau mengklaim biaya aktual.
+- CSV form masih berisi contoh antrean (`Status=New`), bukan laporan yang
+  sudah diverifikasi. Tidak ada perubahan dataset yang diterapkan dari audit
+  ini.
+
+## Tindak lanjut yang aman
+
+1. Maintainer memeriksa laporan Airtable nyata dan menghapus/menandai data
+   contoh sebelum dipakai sebagai antrean produksi.
+2. Untuk tiap kasus, minta bukti bertanggal dan pisahkan biaya transport,
+   logistik barang, serta kesehatan—jangan memasukkan semuanya ke satu angka.
+3. Jika bukti cukup, buat PR data kecil yang mempertahankan `source`, `asOf`,
+   dan `confidence`, lalu jalankan gerbang Zod/CI. Persetujuan tetap manual.

--- a/src/components/AboutPanel.tsx
+++ b/src/components/AboutPanel.tsx
@@ -10,6 +10,8 @@ import {
 } from "@/lib/calculations";
 import type { AffordabilityBand } from "@/lib/types";
 import { useDialogFocus } from "@/lib/useDialogFocus";
+import { CORRECTION_FORM_URL, DISCUSSIONS_URL } from "@/lib/links";
+import { recordUsage } from "@/lib/usage";
 
 const BAND_ORDER: AffordabilityBand[] = [
   "comfortable",
@@ -295,11 +297,31 @@ export function AboutDrawer() {
               <p className="mt-1 leading-relaxed text-muted">
                 Nafkah adalah eksperimen terbuka. Angka upah dan biaya hidup
                 tinggal di file data yang mudah diperiksa dan diperbaiki:
-                tambahkan penetapan resmi terbaru, laporkan selisih, atau
-                sambungkan sumber terverifikasi lewat <em>issue</em> atau{" "}
-                <em>pull request</em> di GitHub — setiap usulan diverifikasi
-                dengan SK/penetapan resmi lewat label keterpercayaan yang sama.
+                laporkan selisih lewat form koreksi atau sambungkan sumber
+                terverifikasi lewat <em>issue</em> atau <em>pull request</em> di
+                GitHub — setiap usulan diverifikasi dengan SK/penetapan resmi
+                lewat label keterpercayaan yang sama.
               </p>
+
+              <div className="mt-3 rounded-xl border border-accent/30 bg-accent-soft p-3.5">
+                <h4 className="text-xs font-bold text-ink">
+                  Menemukan angka yang meleset?
+                </h4>
+                <p className="mt-1 text-[12.5px] leading-relaxed text-muted">
+                  Sertakan wilayah, kategori, nilai lama/usulan, periode, dan
+                  sumber. Laporan masuk ke antrean manual dan tidak mengubah
+                  dataset secara otomatis.
+                </p>
+                <a
+                  href={CORRECTION_FORM_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  onClick={() => recordUsage("correction_report_opened")}
+                  className="mt-2.5 inline-flex h-10 items-center rounded-[10px] bg-accent px-3.5 text-xs font-bold text-on-accent transition-colors hover:bg-accent-strong"
+                >
+                  Laporkan angka via form ↗
+                </a>
+              </div>
 
               <dl className="mt-3 space-y-1.5 rounded-lg border border-border bg-surface p-3 text-[12.5px]">
                 <div className="flex justify-between gap-3">
@@ -328,13 +350,27 @@ export function AboutDrawer() {
               </dl>
 
               <a
-                href={REPO_URL}
+                href={DISCUSSIONS_URL}
                 target="_blank"
                 rel="noreferrer"
                 className="mt-3 inline-flex h-10 items-center gap-1.5 rounded-[10px] border border-border px-3.5 text-xs font-bold text-ink transition-colors hover:border-accent hover:text-accent"
               >
-                Lihat kode &amp; kirim koreksi di GitHub ↗
+                Saran fitur &amp; bug di Discussions ↗
               </a>
+              <a
+                href={REPO_URL}
+                target="_blank"
+                rel="noreferrer"
+                className="ml-2 mt-3 inline-flex h-10 items-center gap-1.5 rounded-[10px] border border-border px-3.5 text-xs font-bold text-ink transition-colors hover:border-accent hover:text-accent"
+              >
+                Lihat kode &amp; kirim PR ↗
+              </a>
+
+              <p className="mt-3 rounded-lg border border-border bg-surface p-3 text-[11.5px] leading-relaxed text-muted">
+                Privasi penggunaan: aplikasi hanya menyimpan hitungan event
+                agregat di browser ini. URL, kode wilayah, nilai asumsi, dan
+                angka finansial tidak dicatat atau dikirim ke pihak ketiga.
+              </p>
             </section>
 
             <div className="flex flex-col gap-2 border-t border-border pt-4 sm:flex-row">

--- a/src/components/Comparison.tsx
+++ b/src/components/Comparison.tsx
@@ -128,7 +128,7 @@ export function PinnedTray() {
 }
 
 export function ComparisonPanel() {
-  const { state, metrics, regionByCode } = useApp();
+  const { state, metrics, regionByCode, setOrigin } = useApp();
   const [open, setOpen] = useState(true);
   const [showChart, setShowChart] = useState(() =>
     shouldRenderComparisonChart(
@@ -136,6 +136,9 @@ export function ComparisonPanel() {
     ),
   );
   const customActive = (state.assumptions.customIncome ?? 0) > 0;
+  const origin = state.originCode
+    ? regionByCode.get(state.originCode)
+    : undefined;
 
   useEffect(() => {
     const syncChartVisibility = () =>
@@ -194,6 +197,31 @@ export function ComparisonPanel() {
         </button>
       </header>
 
+      <div className="border-b border-border bg-surface px-4 py-2.5 text-[11.5px] leading-relaxed">
+        {origin ? (
+          <div className="flex items-center justify-between gap-3">
+            <p>
+              <strong>Relokasi aktif:</strong> gaji asal dari{" "}
+              <span className="font-semibold">{origin.name}</span> → biaya
+              setiap kolom tetap dihitung sebagai kota tujuan.
+            </p>
+            <button
+              type="button"
+              onClick={() => setOrigin(null)}
+              className="shrink-0 rounded-md border border-border px-2 py-1 font-semibold text-muted hover:border-accent hover:text-accent"
+            >
+              Hapus asal
+            </button>
+          </div>
+        ) : (
+          <p className="text-muted">
+            Tip relokasi: buka detail satu wilayah lalu pilih{" "}
+            <strong className="text-ink">Jadikan gaji asal</strong>. Biaya
+            pada panel ini tetap mengikuti kota tujuan.
+          </p>
+        )}
+      </div>
+
       {open && (
         <div className="comparison-content grid min-w-0 gap-4 p-3 sm:p-4 lg:grid-cols-[minmax(0,1.25fr)_minmax(300px,.75fr)]">
           {/* Cards are easier to scan than a squeezed table on phones. */}
@@ -217,12 +245,14 @@ export function ComparisonPanel() {
                     value={formatIDRCompact(m.totalMonthlyCost)}
                   />
                   <MobileMetric
-                    label={customActive ? "Pendapatan" : "UMK"}
+                    label={
+                      origin ? "Gaji asal" : customActive ? "Pendapatan" : "UMK"
+                    }
                     value={formatIDRCompact(m.wageAmount)}
                   />
-                  {customActive && (
+                  {(customActive || origin) && (
                     <MobileMetric
-                      label="UMK daerah"
+                      label={origin ? "UMK tujuan" : "UMK daerah"}
                       value={formatIDRCompact(m.regionalWageAmount)}
                     />
                   )}
@@ -290,15 +320,21 @@ export function ComparisonPanel() {
                   </td>
                 ))}
               </Row>
-              <Row label={customActive ? "Pendapatan" : "UMK (basis)"}>
+              <Row
+                label={
+                  origin ? "Gaji asal" : customActive ? "Pendapatan" : "UMK (basis)"
+                }
+              >
                 {pinnedMetrics.map((m) => (
                   <td key={m.code} className="px-1 py-1.5 text-right">
                     {formatIDRCompact(m.wageAmount)}
                   </td>
                 ))}
               </Row>
-              {customActive && (
-                <Row label="UMK daerah (pembanding)">
+              {(customActive || origin) && (
+                <Row
+                  label={origin ? "UMK tujuan (pembanding)" : "UMK daerah (pembanding)"}
+                >
                   {pinnedMetrics.map((m) => (
                     <td key={m.code} className="px-1 py-1.5 text-right">
                       {formatIDRCompact(m.regionalWageAmount)}

--- a/src/components/DetailModal.tsx
+++ b/src/components/DetailModal.tsx
@@ -22,6 +22,8 @@ import {
 } from "@/lib/format";
 import type { Confidence } from "@/lib/types";
 import { useDialogFocus } from "@/lib/useDialogFocus";
+import { CORRECTION_FORM_URL } from "@/lib/links";
+import { recordUsage } from "@/lib/usage";
 
 /**
  * Region detail modal. Opens on region click (map or search).
@@ -29,7 +31,15 @@ import { useDialogFocus } from "@/lib/useDialogFocus";
  * focus returns to the trigger element on close.
  */
 export function DetailModal() {
-  const { state, metrics, metricsReady, regionByCode, select, pin } = useApp();
+  const {
+    state,
+    metrics,
+    metricsReady,
+    regionByCode,
+    select,
+    pin,
+    setOrigin,
+  } = useApp();
   const bandPalette = bandColors(state.darkMode);
   const isDualIncome =
     state.assumptions.dualIncome &&
@@ -56,6 +66,14 @@ export function DetailModal() {
   const costs = metricsReady ? state.costs.get(code) : undefined;
   const narrative = state.narratives.get(code);
   const isPinned = state.pinned.includes(code);
+  const isOrigin = state.originCode === code;
+  const originRegion = state.originCode
+    ? regionByCode.get(state.originCode)
+    : undefined;
+  const wageProvenance =
+    metric?.wageSource === "origin" && state.originCode
+      ? state.wages.get(state.originCode) ?? wage
+      : wage;
 
   return (
     <div
@@ -96,6 +114,21 @@ export function DetailModal() {
                 </span>
                 <span className="hidden sm:inline">
                   {isPinned ? "Sudah disematkan" : "Pin untuk dibandingkan"}
+                </span>
+              </button>
+            )}
+            {wage && (
+              <button
+                type="button"
+                onClick={() => setOrigin(isOrigin ? null : code)}
+                aria-pressed={isOrigin}
+                className="rounded-lg border border-border px-2.5 py-1.5 text-sm font-medium text-muted transition-colors hover:border-accent hover:text-accent sm:px-3"
+              >
+                <span className="sm:hidden">
+                  {isOrigin ? "Asal aktif" : "Jadikan asal"}
+                </span>
+                <span className="hidden sm:inline">
+                  {isOrigin ? "Hapus kota asal" : "Jadikan gaji asal"}
                 </span>
               </button>
             )}
@@ -142,6 +175,8 @@ export function DetailModal() {
                       metric.wageSource === "custom"
                         ? "Pendapatanmu (input sendiri)" +
                           (isDualIncome ? " + UMK pasangan" : "")
+                        : metric.wageSource === "origin"
+                          ? "Gaji asal (UMK)" + (isDualIncome ? " × 2" : "")
                         : (state.assumptions.wageBasis === "gross"
                             ? "UMK (kotor)"
                             : "UMK (est. take-home)") +
@@ -149,18 +184,30 @@ export function DetailModal() {
                     }
                     value={formatIDR(metric.wageAmount)}
                     provenance={
-                      metric.wageSource === "custom" ? undefined : wage
+                      metric.wageSource === "custom"
+                        ? undefined
+                        : wageProvenance
                     }
                     note={
                       metric.wageSource === "custom"
                         ? `Pembanding UMK daerah: ${formatIDR(
                             metric.regionalWageAmount,
                           )}`
+                        : metric.wageSource === "origin"
+                          ? `Kota asal: ${
+                              originRegion?.name ?? state.originCode ?? "—"
+                            }. UMK tujuan: ${formatIDR(
+                              metric.regionalWageAmount,
+                            )}`
                         : undefined
                     }
                   />
                   <Kpi
-                    label="Est. biaya bulanan"
+                    label={
+                      state.originCode
+                        ? "Est. biaya kota tujuan"
+                        : "Est. biaya bulanan"
+                    }
                     value={formatIDR(metric.totalMonthlyCost)}
                     provenance={{
                       source: "Lihat tabel kategori di bawah",
@@ -187,6 +234,19 @@ export function DetailModal() {
                     }
                   />
                 </dl>
+
+                {state.originCode && (
+                  <p className="-mt-2 rounded-lg border border-accent/30 bg-accent-soft p-3 text-[12px] leading-relaxed">
+                    <strong>Mode relokasi:</strong> gaji asal dari{" "}
+                    <span className="font-semibold">
+                      {originRegion?.name ?? state.originCode}
+                    </span>{" "}
+                    dibandingkan dengan biaya kota tujuan{" "}
+                    <span className="font-semibold">{displayName}</span>.
+                    {metric.wageSource === "custom" &&
+                      " Pendapatan sendiri tetap menjadi gaji utama; asal dipakai untuk upah pasangan bila 2 upah aktif."}
+                  </p>
+                )}
 
                 {metric.wageSource === "region" && (
                   <p className="-mt-2 text-[11px] leading-relaxed text-muted">
@@ -339,7 +399,16 @@ export function DetailModal() {
                         </tr>
                       </thead>
                       <tbody>
-                        <ProvenanceRow label={`UMK ${wage.year}`} p={wage} />
+                        <ProvenanceRow
+                          label={`${metric.wageSource === "origin" ? "UMK kota asal" : "UMK"} ${wageProvenance!.year}`}
+                          p={wageProvenance!}
+                        />
+                        {metric.wageSource === "origin" && (
+                          <ProvenanceRow
+                            label={`UMK kota tujuan ${wage.year}`}
+                            p={wage}
+                          />
+                        )}
                         {EXPENSE_CATEGORIES.map((c) => (
                           <ProvenanceRow
                             key={c.key}
@@ -357,6 +426,23 @@ export function DetailModal() {
                   riil berbeda menurut lingkungan tempat tinggal, ukuran rumah
                   tangga, tunjangan pekerjaan, dan keadaan personal.
                 </p>
+
+                <div className="flex flex-col gap-2 rounded-xl border border-accent/30 bg-accent-soft p-3 sm:flex-row sm:items-center sm:justify-between">
+                  <p className="text-[12px] leading-relaxed text-muted">
+                    Menemukan angka atau sumber yang perlu diperbaiki? Laporan
+                    diperiksa manual dan tidak mengubah data otomatis.
+                  </p>
+                  <a
+                    href={CORRECTION_FORM_URL}
+                    target="_blank"
+                    rel="noreferrer"
+                    onClick={() => recordUsage("correction_report_opened")}
+                    aria-label={`Laporkan angka untuk ${displayName}`}
+                    className="inline-flex h-10 shrink-0 items-center justify-center rounded-[10px] bg-accent px-3.5 text-xs font-bold text-on-accent transition-colors hover:bg-accent-strong"
+                  >
+                    Laporkan angka ini ↗
+                  </a>
+                </div>
               </>
             )
           ) : (

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useApp } from "@/state/AppContext";
 import { buildShareUrl } from "@/state/share";
+import { recordUsage } from "@/lib/usage";
 
 type ShareStatus = "idle" | "copied" | "shared" | "error";
 
@@ -43,10 +44,12 @@ export function ShareButton() {
   };
 
   const share = async () => {
+    recordUsage("share_requested");
     const url = buildShareUrl(window.location.href, {
       assumptions: state.assumptions,
       pinned: state.pinned,
       selectedCode: state.selectedCode,
+      originCode: state.originCode,
       colorMode: state.colorMode,
       legendFilter: state.legendFilter,
     });
@@ -58,10 +61,12 @@ export function ShareButton() {
           text: "Lihat perbandingan upah dan biaya hidup dengan asumsi ini.",
           url,
         });
+        recordUsage("share_completed");
         showStatus("shared");
         return;
       }
       await copyText(url);
+      recordUsage("share_completed");
       showStatus("copied");
     } catch (error) {
       if (error instanceof DOMException && error.name === "AbortError") return;

--- a/src/components/StatusChips.tsx
+++ b/src/components/StatusChips.tsx
@@ -8,7 +8,7 @@ import { useApp } from "@/state/AppContext";
  * (yang ketiga tampil di tooltip + modal detail).
  */
 export function StatusChips() {
-  const { state, retryGeometry, retryData } = useApp();
+  const { state, regionByCode, retryGeometry, retryData, setOrigin } = useApp();
 
   const chips: React.ReactNode[] = [];
 
@@ -40,6 +40,27 @@ export function StatusChips() {
         onAction={retryData}
         detail={state.dataError ?? undefined}
       />,
+    );
+  }
+
+  if (state.originCode) {
+    chips.push(
+      <div
+        key="origin"
+        role="status"
+        className="flex items-center gap-2 rounded-full border border-accent/40 bg-accent-soft px-3.5 py-1.5 text-xs font-medium text-accent shadow-md backdrop-blur"
+      >
+        <span>
+          Gaji asal: {regionByCode.get(state.originCode)?.name ?? state.originCode}
+        </span>
+        <button
+          type="button"
+          onClick={() => setOrigin(null)}
+          className="rounded bg-current/10 px-2 py-0.5 font-semibold underline underline-offset-2"
+        >
+          Hapus
+        </button>
+      </div>,
     );
   }
 

--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -136,7 +136,10 @@ function ClosingCard({ narrow }: { narrow: boolean }) {
   const recap = [
     { t: "Cari wilayah", d: "atau klik langsung di peta." },
     { t: "Sematkan sampai 5", d: "untuk membandingkan cakupan & saldonya." },
-    { t: "Ubah asumsi", d: "rumah tangga, hunian, pendapatan sendiri." },
+    {
+      t: "Ubah asumsi",
+      d: "rumah tangga, hunian, pendapatan sendiri, atau gaji asal relokasi.",
+    },
   ];
   const close = () => setTourIdx(null);
   const dialogRef = useDialogFocus<HTMLDivElement>(true, close);

--- a/src/components/onboarding/ThreeStepCard.tsx
+++ b/src/components/onboarding/ThreeStepCard.tsx
@@ -13,7 +13,7 @@ const STEPS = [
   },
   {
     t: "Ubah asumsi",
-    d: "rumah tangga, hunian, atau pendapatan sendiri — peta mewarnai ulang seketika.",
+    d: "rumah tangga, hunian, pendapatan sendiri, atau gaji asal — peta mewarnai ulang seketika.",
   },
 ];
 

--- a/src/components/onboarding/tour.ts
+++ b/src/components/onboarding/tour.ts
@@ -52,7 +52,7 @@ export const TOUR_BROAD: TourStep[] = [
   {
     key: "asumsi",
     title: "Sesuaikan dengan hidupmu",
-    body: "Single atau keluarga, kost atau KPR, motor atau ojol — bahkan gaji kamu sendiri. Peta mewarnai ulang seketika.",
+    body: "Single atau keluarga, kost atau KPR, motor atau ojol — bahkan gaji kamu sendiri. Untuk relokasi, jadikan upah satu wilayah sebagai gaji asal. Peta mewarnai ulang seketika.",
     tip: "Gaji yang kamu isi hanya tersimpan di browsermu.",
   },
 ];
@@ -78,7 +78,7 @@ export const TOUR_NARROW: TourStep[] = [
   {
     key: "asumsi",
     title: "Sesuaikan dengan hidupmu",
-    body: "Single atau keluarga, kost atau KPR, motor atau ojol — bahkan gaji kamu sendiri. Peta mewarnai ulang seketika.",
+    body: "Single atau keluarga, kost atau KPR, motor atau ojol — bahkan gaji kamu sendiri. Untuk relokasi, jadikan upah satu wilayah sebagai gaji asal.",
     tip: "Gaji yang kamu isi hanya tersimpan di browsermu.",
   },
 ];

--- a/src/lib/calculations.test.ts
+++ b/src/lib/calculations.test.ts
@@ -174,6 +174,51 @@ describe("computeMetrics", () => {
     });
     expect(m.wageAmount).toBe(50_000_000 + wage.grossMonthly);
   });
+
+  it("uses the origin wage while keeping the destination wage as comparator", () => {
+    const destinationWage = makeWage(3_000_000);
+    const originWage = {
+      ...makeWage(5_000_000),
+      regionCode: "01.01",
+    };
+    const m = computeMetrics(
+      "02.02",
+      destinationWage,
+      makeCosts(),
+      DEFAULT_ASSUMPTIONS,
+      AFFORDABILITY_BANDS,
+      originWage,
+    );
+
+    expect(m.wageAmount).toBe(originWage.grossMonthly);
+    expect(m.wageSource).toBe("origin");
+    expect(m.regionalWageAmount).toBe(destinationWage.grossMonthly);
+  });
+
+  it("uses the origin wage for the partner when custom income is active", () => {
+    const destinationWage = makeWage(3_000_000);
+    const originWage = {
+      ...makeWage(2_000_000),
+      regionCode: "01.01",
+    };
+    const m = computeMetrics(
+      "02.02",
+      destinationWage,
+      makeCosts(),
+      {
+        ...DEFAULT_ASSUMPTIONS,
+        householdType: "couple",
+        dualIncome: true,
+        customIncome: 7_000_000,
+      },
+      AFFORDABILITY_BANDS,
+      originWage,
+    );
+
+    expect(m.wageAmount).toBe(9_000_000);
+    expect(m.wageSource).toBe("custom");
+    expect(m.regionalWageAmount).toBe(6_000_000);
+  });
 });
 
 /* ---------- AP-03: jumlah anak & cicilan KPR ---------- */

--- a/src/lib/calculations.ts
+++ b/src/lib/calculations.ts
@@ -22,7 +22,9 @@ import {
  *   wageBasisAmount    = earners × (wageBasis === 'gross' ? grossMonthly : estimatedTakeHomeMonthly)
  *                          earners = 2 jika pasangan ikut bekerja (default 1)
  *   Dengan pendapatan sendiri (customIncome > 0):
- *     wageAmount = customIncome + (earners === 2 ? upah daerah 1 pekerja : 0)
+ *     wageAmount = customIncome + (earners === 2 ? upah dari kota asal 1 pekerja : 0)
+ *   Dengan kota asal relokasi:
+ *     wageAmount = upah kota asal × earners, sedangkan biaya tetap dari kota tujuan.
  *   regionalWageAmount selalu = upah daerah (pembanding & layer peta "Upah").
  *   Per-anak (AP-03): pengali rumah tangga + children × CHILD_MULTIPLIERS.
  *   Cicilan KPR (AP-03): installmentMonthly menggantikan kategori hunian.
@@ -160,6 +162,7 @@ export function computeMetrics(
   costs: CostProfile,
   assumptions: Assumptions,
   bands: AffordabilityBands = AFFORDABILITY_BANDS,
+  originWage?: WageRecord,
 ): RegionMetrics {
   // Dua penghasilan hanya untuk rumah tangga berpasangan: pasangan diasumsikan
   // bekerja dengan upah minimum (UMK/UMP) daerah yang sama.
@@ -170,16 +173,21 @@ export function computeMetrics(
       ? wage.grossMonthly
       : wage.estimatedTakeHomeMonthly;
   const regionalWageAmount = earners * regionalSingle;
+  const incomeSingle = originWage
+    ? assumptions.wageBasis === "gross"
+      ? originWage.grossMonthly
+      : originWage.estimatedTakeHomeMonthly
+    : regionalSingle;
   // Pendapatan sendiri menggantikan upah pengguna; dengan "2 upah", pasangan
   // tetap diasumsikan berupah minimum (UMK/UMP) daerah yang sama.
   const customIncomeActive =
     assumptions.customIncome != null && assumptions.customIncome > 0;
-  // Pendapatan sendiri menggantikan upah pengguna; dengan "2 upah", pasangan
-  // tetap diasumsikan berupah minimum (UMK/UMP) daerah yang sama.
   let wageAmount = regionalWageAmount;
   if (assumptions.customIncome != null && assumptions.customIncome > 0) {
     wageAmount =
-      assumptions.customIncome + (earners === 2 ? regionalSingle : 0);
+      assumptions.customIncome + (earners === 2 ? incomeSingle : 0);
+  } else if (originWage) {
+    wageAmount = earners * incomeSingle;
   }
 
   const breakdown = adjustCosts(costs, assumptions);
@@ -191,7 +199,7 @@ export function computeMetrics(
     code,
     wageAmount,
     regionalWageAmount,
-    wageSource: customIncomeActive ? "custom" : "region",
+    wageSource: customIncomeActive ? "custom" : originWage ? "origin" : "region",
     totalMonthlyCost,
     coveragePercent,
     surplusOrDeficit: wageAmount - totalMonthlyCost,
@@ -208,13 +216,17 @@ export function computeAllMetrics(
   costs: Map<string, CostProfile>,
   assumptions: Assumptions,
   bands: AffordabilityBands = AFFORDABILITY_BANDS,
+  originWage?: WageRecord,
 ): Map<string, RegionMetrics> {
   const out = new Map<string, RegionMetrics>();
   for (const code of codes) {
     const wage = wages.get(code);
     const cost = costs.get(code);
     if (!wage || !cost) continue;
-    out.set(code, computeMetrics(code, wage, cost, assumptions, bands));
+    out.set(
+      code,
+      computeMetrics(code, wage, cost, assumptions, bands, originWage),
+    );
   }
   return out;
 }

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -1,0 +1,5 @@
+/** Public contribution channels; no credentials or write API are used by the app. */
+export const CORRECTION_FORM_URL =
+  "https://airtable.com/appri285dCNF5mqc/pagbuVQAdt3s9mEaV/form";
+
+export const DISCUSSIONS_URL = "https://github.com/adenaufal/nafkah/discussions";

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -107,8 +107,11 @@ export interface RegionMetrics {
  wageAmount: number;
  /** Upah daerah berbasis UMK/UMP — pembanding saat pendapatan custom aktif. */
  regionalWageAmount: number;
- /** Sumber pembagi rasio keterjangkauan: upah daerah atau pendapatan sendiri. */
- wageSource: "region" | "custom";
+ /**
+  * Sumber pembagi rasio keterjangkauan: upah tujuan, gaji asal, atau
+  * pendapatan sendiri.
+  */
+ wageSource: "region" | "origin" | "custom";
  totalMonthlyCost: number;
  coveragePercent: number;
  surplusOrDeficit: number;

--- a/src/lib/usage.test.ts
+++ b/src/lib/usage.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import {
+  readUsageCounts,
+  recordUsage,
+  type UsageStorage,
+} from "./usage";
+
+function memoryStorage(initial?: string): UsageStorage & { value: string | null } {
+  return {
+    value: initial ?? null,
+    getItem() {
+      return this.value;
+    },
+    setItem(_key, value) {
+      this.value = value;
+    },
+  };
+}
+
+describe("privacy-first usage counters", () => {
+  it("increments only named aggregate events", () => {
+    const storage = memoryStorage();
+
+    recordUsage("region_opened", storage);
+    recordUsage("region_opened", storage);
+    recordUsage("share_completed", storage);
+
+    const counts = readUsageCounts(storage);
+    expect(counts.region_opened).toBe(2);
+    expect(counts.share_completed).toBe(1);
+    expect(storage.value).toContain('"region_opened":2');
+    expect(storage.value).not.toContain("31.73");
+  });
+
+  it("ignores malformed or unknown local state", () => {
+    const storage = memoryStorage(
+      JSON.stringify({ region_opened: -2, unknown: 99, share_completed: 3.5 }),
+    );
+
+    const counts = readUsageCounts(storage);
+    expect(counts.region_opened).toBe(0);
+    expect(counts.share_completed).toBe(0);
+    expect(counts.assumptions_changed).toBe(0);
+  });
+});

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -1,0 +1,86 @@
+/**
+ * Privacy-first usage counters.
+ *
+ * Only aggregate event names are stored locally. No URL, region code,
+ * assumption value, or financial input is recorded, and nothing is sent to a
+ * third party. Keeping this as a tiny opt-in-to-the-browser layer lets us
+ * validate the important journey without introducing analytics credentials or
+ * a server into the static app.
+ */
+
+export const USAGE_STORAGE_KEY = "nafkah.usage.v1";
+
+export const USAGE_EVENTS = [
+  "region_opened",
+  "region_pinned",
+  "comparison_started",
+  "assumptions_changed",
+  "legend_mode_changed",
+  "legend_filter_changed",
+  "theme_toggled",
+  "basemap_changed",
+  "relocation_origin_set",
+  "relocation_origin_cleared",
+  "share_requested",
+  "share_completed",
+  "correction_report_opened",
+] as const;
+
+export type UsageEvent = (typeof USAGE_EVENTS)[number];
+export type UsageCounts = Record<UsageEvent, number>;
+
+export type UsageStorage = Pick<Storage, "getItem" | "setItem">;
+
+function browserStorage(): UsageStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function emptyCounts(): UsageCounts {
+  return Object.fromEntries(
+    USAGE_EVENTS.map((event) => [event, 0]),
+  ) as UsageCounts;
+}
+
+/** Read counters defensively; old or edited browser state degrades to zero. */
+export function readUsageCounts(
+  storage: UsageStorage | null = browserStorage(),
+): UsageCounts {
+  const counts = emptyCounts();
+  if (!storage) return counts;
+
+  try {
+    const raw = storage.getItem(USAGE_STORAGE_KEY);
+    if (!raw) return counts;
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return counts;
+    const candidate = parsed as Record<string, unknown>;
+    for (const event of USAGE_EVENTS) {
+      const value = candidate[event];
+      if (typeof value === "number" && Number.isSafeInteger(value) && value >= 0)
+        counts[event] = value;
+    }
+  } catch {
+    return counts;
+  }
+  return counts;
+}
+
+/** Increment one local aggregate counter without ever throwing into the UI. */
+export function recordUsage(
+  event: UsageEvent,
+  storage: UsageStorage | null = browserStorage(),
+): void {
+  if (!storage) return;
+  try {
+    const counts = readUsageCounts(storage);
+    counts[event] += 1;
+    storage.setItem(USAGE_STORAGE_KEY, JSON.stringify(counts));
+  } catch {
+    /* Private browsing or strict storage policies must not break the app. */
+  }
+}

--- a/src/state/AppContext.tsx
+++ b/src/state/AppContext.tsx
@@ -7,6 +7,7 @@ import {
   useEffect,
   useMemo,
   useReducer,
+  useRef,
   type ReactNode,
 } from "react";
 import type {
@@ -30,6 +31,7 @@ import {
 import { loadGeometry, loadDataset } from "@/data/loader";
 import { loadPersisted, savePersisted } from "./persist";
 import { decodeSharedView } from "./share";
+import { recordUsage } from "@/lib/usage";
 import type { FeatureCollection, Geometry } from "geojson";
 
 export const MAX_PINS = 5;
@@ -52,6 +54,8 @@ interface AppState {
   pinned: string[];
   pinMessage: string | null;
   selectedCode: string | null;
+  /** Optional wage source for relocation mode; costs always stay per destination. */
+  originCode: string | null;
   colorMode: ColorMode;
   legendFilter: AffordabilityBand | null;
   basemap: BasemapId;
@@ -82,6 +86,7 @@ const initialState: AppState = {
   pinned: [],
   pinMessage: null,
   selectedCode: null,
+  originCode: null,
   colorMode: "coverage",
   legendFilter: null,
   basemap: "light",
@@ -108,9 +113,13 @@ function initState(base: AppState): AppState {
     darkMode: p.darkMode ?? base.darkMode,
     assumptions: shared?.assumptions ?? p.assumptions ?? base.assumptions,
     pinned: shared?.pinned ?? p.pinned ?? base.pinned,
-    selectedCode: shared?.selectedCode ?? base.selectedCode,
-    colorMode: shared?.colorMode ?? base.colorMode,
-    legendFilter: shared?.legendFilter ?? base.legendFilter,
+    selectedCode:
+      shared ? shared.selectedCode : p.selectedCode ?? base.selectedCode,
+    originCode: shared ? shared.originCode : p.originCode ?? base.originCode,
+    colorMode: shared?.colorMode ?? p.colorMode ?? base.colorMode,
+    legendFilter: shared?.legendFilter ?? p.legendFilter ?? base.legendFilter,
+    basemap: p.basemap ?? base.basemap,
+    basemapUserSet: p.basemap != null,
     onboarded,
     onboardCardOpen: shared ? false : !p.onboardCardDismissed,
     // First visit opens the guide; returning visitors land straight on the map.
@@ -137,6 +146,7 @@ type Action =
   | { type: "pin/remove"; code: string }
   | { type: "pin/clearMessage" }
   | { type: "select"; code: string | null }
+  | { type: "origin/set"; code: string | null }
   | { type: "colorMode/set"; mode: ColorMode }
   | { type: "legendFilter/set"; band: AffordabilityBand | null }
   | { type: "basemap/set"; basemap: BasemapId }
@@ -174,6 +184,12 @@ function reducer(state: AppState, action: Action): AppState {
         selectedCode:
           state.selectedCode && validCodes.has(state.selectedCode)
             ? state.selectedCode
+            : null,
+        originCode:
+          state.originCode &&
+          validCodes.has(state.originCode) &&
+          action.wages.has(state.originCode)
+            ? state.originCode
             : null,
       };
     }
@@ -215,6 +231,8 @@ function reducer(state: AppState, action: Action): AppState {
       return { ...state, pinMessage: null };
     case "select":
       return { ...state, selectedCode: action.code };
+    case "origin/set":
+      return { ...state, originCode: action.code };
     case "colorMode/set":
       return { ...state, colorMode: action.mode };
     case "legendFilter/set":
@@ -273,6 +291,7 @@ interface AppContextValue {
   pin: (code: string) => void;
   unpin: (code: string) => void;
   select: (code: string | null) => void;
+  setOrigin: (code: string | null) => void;
   setColorMode: (m: ColorMode) => void;
   setLegendFilter: (b: AffordabilityBand | null) => void;
   setBasemap: (b: BasemapId) => void;
@@ -343,6 +362,26 @@ export function AppProvider({ children }: { children: ReactNode }) {
   );
   useEffect(() => savePersisted({ pinned: state.pinned }), [state.pinned]);
   useEffect(
+    () => savePersisted({ selectedCode: state.selectedCode }),
+    [state.selectedCode],
+  );
+  useEffect(
+    () => savePersisted({ originCode: state.originCode }),
+    [state.originCode],
+  );
+  useEffect(
+    () => savePersisted({ colorMode: state.colorMode }),
+    [state.colorMode],
+  );
+  useEffect(
+    () => savePersisted({ legendFilter: state.legendFilter }),
+    [state.legendFilter],
+  );
+  useEffect(
+    () => savePersisted({ basemap: state.basemap }),
+    [state.basemap],
+  );
+  useEffect(
     () => savePersisted({ onboarded: state.onboarded }),
     [state.onboarded],
   );
@@ -358,6 +397,14 @@ export function AppProvider({ children }: { children: ReactNode }) {
     return () => clearTimeout(t);
   }, [state.pinMessage]);
 
+  const previousPinnedCount = useRef(state.pinned.length);
+  useEffect(() => {
+    if (previousPinnedCount.current < 2 && state.pinned.length >= 2) {
+      recordUsage("comparison_started");
+    }
+    previousPinnedCount.current = state.pinned.length;
+  }, [state.pinned.length]);
+
   const codes = useMemo(() => state.regions.map((r) => r.code), [state.regions]);
   const regionByCode = useMemo(
     () => new Map(state.regions.map((r) => [r.code, r])),
@@ -371,8 +418,15 @@ export function AppProvider({ children }: { children: ReactNode }) {
         state.costs,
         state.assumptions,
         AFFORDABILITY_BANDS,
+        state.originCode ? state.wages.get(state.originCode) : undefined,
       ),
-    [codes, state.wages, state.costs, state.assumptions],
+    [
+      codes,
+      state.wages,
+      state.costs,
+      state.assumptions,
+      state.originCode,
+    ],
   );
   const metricsReady = state.dataStatus === "ready";
 
@@ -381,16 +435,45 @@ export function AppProvider({ children }: { children: ReactNode }) {
     metrics,
     metricsReady,
     regionByCode,
-    setAssumptions: (a) =>
-      dispatch({ type: "assumptions/set", assumptions: a }),
-    resetAssumptions: () => dispatch({ type: "assumptions/reset" }),
-    pin: (code) => dispatch({ type: "pin/add", code }),
+    setAssumptions: (a) => {
+      recordUsage("assumptions_changed");
+      dispatch({ type: "assumptions/set", assumptions: a });
+    },
+    resetAssumptions: () => {
+      recordUsage("assumptions_changed");
+      dispatch({ type: "assumptions/reset" });
+    },
+    pin: (code) => {
+      recordUsage("region_pinned");
+      dispatch({ type: "pin/add", code });
+    },
     unpin: (code) => dispatch({ type: "pin/remove", code }),
-    select: (code) => dispatch({ type: "select", code }),
-    setColorMode: (mode) => dispatch({ type: "colorMode/set", mode }),
-    setLegendFilter: (band) => dispatch({ type: "legendFilter/set", band }),
-    setBasemap: (basemap) => dispatch({ type: "basemap/set", basemap }),
-    setDarkMode: (dark) => dispatch({ type: "theme/set", dark }),
+    select: (code) => {
+      if (code) recordUsage("region_opened");
+      dispatch({ type: "select", code });
+    },
+    setOrigin: (code) => {
+      recordUsage(
+        code ? "relocation_origin_set" : "relocation_origin_cleared",
+      );
+      dispatch({ type: "origin/set", code });
+    },
+    setColorMode: (mode) => {
+      recordUsage("legend_mode_changed");
+      dispatch({ type: "colorMode/set", mode });
+    },
+    setLegendFilter: (band) => {
+      recordUsage("legend_filter_changed");
+      dispatch({ type: "legendFilter/set", band });
+    },
+    setBasemap: (basemap) => {
+      recordUsage("basemap_changed");
+      dispatch({ type: "basemap/set", basemap });
+    },
+    setDarkMode: (dark) => {
+      recordUsage("theme_toggled");
+      dispatch({ type: "theme/set", dark });
+    },
     resetView: () => dispatch({ type: "view/reset" }),
     retryGeometry: () => void loadGeo(),
     retryData: () => void loadData(),

--- a/src/state/persist.test.ts
+++ b/src/state/persist.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { MAX_CHILDREN, normalizeAssumptions } from "./persist";
+import {
+  MAX_CHILDREN,
+  normalizeAssumptions,
+  normalizePersisted,
+} from "./persist";
 import { DEFAULT_ASSUMPTIONS } from "@/lib/calculations";
 import type { Assumptions } from "@/lib/types";
 
@@ -61,5 +65,26 @@ describe("normalizeAssumptions", () => {
     expect(normalizeAssumptions(null)).toEqual(DEFAULT_ASSUMPTIONS);
     expect(normalizeAssumptions(undefined)).toEqual(DEFAULT_ASSUMPTIONS);
     expect(normalizeAssumptions({})).toEqual(DEFAULT_ASSUMPTIONS);
+  });
+
+  it("menormalkan preferensi tampilan dan asal relokasi dari storage", () => {
+    expect(
+      normalizePersisted({
+        selectedCode: "31.73",
+        originCode: "32.73",
+        pinned: ["31.73", "bad", "31.73"],
+        colorMode: "cost",
+        legendFilter: null,
+        basemap: "offline",
+        darkMode: "yes",
+      }),
+    ).toEqual({
+      selectedCode: "31.73",
+      originCode: "32.73",
+      pinned: ["31.73"],
+      colorMode: "cost",
+      legendFilter: null,
+      basemap: "offline",
+    });
   });
 });

--- a/src/state/persist.ts
+++ b/src/state/persist.ts
@@ -6,7 +6,12 @@
  */
 
 import { DEFAULT_ASSUMPTIONS } from "@/lib/calculations";
-import type { Assumptions } from "@/lib/types";
+import type {
+  AffordabilityBand,
+  Assumptions,
+  BasemapId,
+  ColorMode,
+} from "@/lib/types";
 
 const KEY = "nafkah.v1";
 
@@ -19,6 +24,93 @@ export interface Persisted {
   onboardCardDismissed?: boolean;
   assumptions?: Assumptions;
   pinned?: string[];
+  selectedCode?: string | null;
+  originCode?: string | null;
+  colorMode?: ColorMode;
+  legendFilter?: AffordabilityBand | null;
+  basemap?: BasemapId;
+}
+
+const REGION_CODE = /^\d{2}\.\d{2}$/;
+const MAX_PERSISTED_PINS = 5;
+const COLOR_MODES: ColorMode[] = ["coverage", "cost", "wage"];
+const BANDS: AffordabilityBand[] = [
+  "comfortable",
+  "manageable",
+  "tight",
+  "insufficient",
+];
+const BASEMAPS: BasemapId[] = ["light", "dark", "satellite", "offline"];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function optionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function optionalRegionCode(value: unknown): string | null | undefined {
+  if (value === null) return null;
+  return typeof value === "string" && REGION_CODE.test(value) ? value : undefined;
+}
+
+function optionalEnum<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+): T | undefined {
+  return typeof value === "string" && allowed.includes(value as T)
+    ? (value as T)
+    : undefined;
+}
+
+/**
+ * Treat localStorage as untrusted input. Invalid preferences are discarded so
+ * a hand-edited or stale value cannot poison the map state on the next visit.
+ */
+export function normalizePersisted(input: unknown): Persisted {
+  if (!isRecord(input)) return {};
+
+  const out: Persisted = {};
+  const darkMode = optionalBoolean(input.darkMode);
+  const onboarded = optionalBoolean(input.onboarded);
+  const onboardCardDismissed = optionalBoolean(input.onboardCardDismissed);
+  if (darkMode !== undefined) out.darkMode = darkMode;
+  if (onboarded !== undefined) out.onboarded = onboarded;
+  if (onboardCardDismissed !== undefined)
+    out.onboardCardDismissed = onboardCardDismissed;
+
+  if (isRecord(input.assumptions)) {
+    out.assumptions = normalizeAssumptions(input.assumptions as Partial<Assumptions>);
+  }
+
+  if (Array.isArray(input.pinned)) {
+    out.pinned = [
+      ...new Set(
+        input.pinned.filter(
+          (code): code is string =>
+            typeof code === "string" && REGION_CODE.test(code),
+        ),
+      ),
+    ].slice(0, MAX_PERSISTED_PINS);
+  }
+
+  const selectedCode = optionalRegionCode(input.selectedCode);
+  const originCode = optionalRegionCode(input.originCode);
+  if (selectedCode !== undefined) out.selectedCode = selectedCode;
+  if (originCode !== undefined) out.originCode = originCode;
+
+  const colorMode = optionalEnum(input.colorMode, COLOR_MODES);
+  const legendFilter =
+    input.legendFilter === null
+      ? null
+      : optionalEnum(input.legendFilter, BANDS);
+  const basemap = optionalEnum(input.basemap, BASEMAPS);
+  if (colorMode !== undefined) out.colorMode = colorMode;
+  if (legendFilter !== undefined) out.legendFilter = legendFilter;
+  if (basemap !== undefined) out.basemap = basemap;
+
+  return out;
 }
 
 /**
@@ -53,13 +145,7 @@ export function loadPersisted(): Persisted {
   try {
     const raw = window.localStorage.getItem(KEY);
     if (!raw) return {};
-    const parsed = JSON.parse(raw) as Persisted;
-    return {
-      ...parsed,
-      assumptions: parsed.assumptions
-        ? normalizeAssumptions(parsed.assumptions)
-        : undefined,
-    };
+    return normalizePersisted(JSON.parse(raw));
   } catch {
     return {};
   }
@@ -69,7 +155,10 @@ export function savePersisted(patch: Persisted): void {
   if (typeof window === "undefined") return;
   try {
     const current = loadPersisted();
-    window.localStorage.setItem(KEY, JSON.stringify({ ...current, ...patch }));
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify(normalizePersisted({ ...current, ...patch })),
+    );
   } catch {
     /* storage unavailable — degrade silently */
   }

--- a/src/state/share.test.ts
+++ b/src/state/share.test.ts
@@ -17,20 +17,31 @@ describe("shared view URL", () => {
       assumptions,
       pinned: ["31.73", "32.73"],
       selectedCode: "32.73",
+      originCode: "31.73",
       colorMode: "cost",
       legendFilter: "tight",
     });
 
     const parsedUrl = new URL(url);
     expect(parsedUrl.searchParams.has("utm_source")).toBe(false);
+    expect(parsedUrl.searchParams.get("naf")).toBe("2");
     expect(parsedUrl.hash).toBe("#map");
     expect(decodeSharedView(parsedUrl.search)).toEqual({
       assumptions,
       pinned: ["31.73", "32.73"],
       selectedCode: "32.73",
+      originCode: "31.73",
       colorMode: "cost",
       legendFilter: "tight",
     });
+  });
+
+  it("keeps reading v1 links without an origin region", () => {
+    const view = decodeSharedView("?naf=1&r=31.73&f=31.73&color=coverage");
+
+    expect(view?.pinned).toEqual(["31.73"]);
+    expect(view?.selectedCode).toBe("31.73");
+    expect(view?.originCode).toBeNull();
   });
 
   it("ignores URLs without a supported Nafkah share version", () => {
@@ -42,7 +53,7 @@ describe("shared view URL", () => {
     const view = decodeSharedView(
       "?naf=1&r=31.73,31.73,bad,32.73,33.73,34.71,35.78,36.71" +
         "&f=not-a-code&hh=unknown&kids=99&income=-20&installment=abc" +
-        "&color=neon&band=unknown",
+        "&origin=not-a-code&color=neon&band=unknown",
     );
 
     expect(view).not.toBeNull();
@@ -54,6 +65,7 @@ describe("shared view URL", () => {
       "35.78",
     ]);
     expect(view?.selectedCode).toBeNull();
+    expect(view?.originCode).toBeNull();
     expect(view?.assumptions).toEqual(DEFAULT_ASSUMPTIONS);
     expect(view?.colorMode).toBe("coverage");
     expect(view?.legendFilter).toBeNull();

--- a/src/state/share.ts
+++ b/src/state/share.ts
@@ -11,7 +11,12 @@ import type {
 } from "@/lib/types";
 import { MAX_CHILDREN, normalizeAssumptions } from "./persist";
 
-const SHARE_VERSION = "1";
+/**
+ * v2 adds an optional `origin` wage region for relocation comparisons. The
+ * decoder still accepts v1 so links shared before AP-07 remain valid.
+ */
+const SHARE_VERSION = "2";
+const SUPPORTED_SHARE_VERSIONS = new Set(["1", SHARE_VERSION]);
 const MAX_SHARED_REGIONS = 5;
 const REGION_CODE = /^\d{2}\.\d{2}$/;
 
@@ -36,6 +41,8 @@ export interface SharedView {
   assumptions: Assumptions;
   pinned: string[];
   selectedCode: string | null;
+  /** Upah source region; destination costs remain represented by `pinned`. */
+  originCode: string | null;
   colorMode: ColorMode;
   legendFilter: AffordabilityBand | null;
 }
@@ -75,6 +82,10 @@ function positiveInteger(value: string | null): number | null {
   return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
+function regionCode(value: string | null): string | null {
+  return value && REGION_CODE.test(value) ? value : null;
+}
+
 function regionCodes(value: string | null): string[] {
   if (!value) return [];
   return [...new Set(value.split(",").filter((code) => REGION_CODE.test(code)))].slice(
@@ -86,7 +97,7 @@ function regionCodes(value: string | null): string[] {
 /** Parse a versioned shared view. Unknown or malformed values degrade safely. */
 export function decodeSharedView(search: string): SharedView | null {
   const params = new URLSearchParams(search);
-  if (params.get("naf") !== SHARE_VERSION) return null;
+  if (!SUPPORTED_SHARE_VERSIONS.has(params.get("naf") ?? "")) return null;
 
   const assumptions = normalizeAssumptions({
     ...DEFAULT_ASSUMPTIONS,
@@ -137,7 +148,8 @@ export function decodeSharedView(search: string): SharedView | null {
   return {
     assumptions,
     pinned: regionCodes(params.get("r")),
-    selectedCode: selected && REGION_CODE.test(selected) ? selected : null,
+    selectedCode: regionCode(selected),
+    originCode: regionCode(params.get("origin")),
     colorMode: enumValue(
       params.get("color"),
       COLOR_MODES,
@@ -162,6 +174,8 @@ export function buildShareUrl(baseUrl: string, view: SharedView): string {
     url.searchParams.set("r", regionCodes(view.pinned.join(",")).join(","));
   if (view.selectedCode && REGION_CODE.test(view.selectedCode))
     url.searchParams.set("f", view.selectedCode);
+  if (view.originCode && REGION_CODE.test(view.originCode))
+    url.searchParams.set("origin", view.originCode);
   url.searchParams.set("hh", a.householdType);
   url.searchParams.set("kids", String(a.children));
   url.searchParams.set("life", a.lifestyle);


### PR DESCRIPTION
## Apa yang diubah

Menyelesaikan batch aman AP-04 sampai AP-07 tanpa mengubah dataset yang di-ship:

- Menambahkan mode relokasi: gaji asal Kota A dibandingkan dengan biaya serta UMK kota tujuan, termasuk status persisten, provenance, dan tampilan perbandingan.
- Menaikkan share URL ke v2 dengan field asal relokasi; decoder tetap membaca URL v1.
- Menambahkan CTA koreksi di detail/About menuju form Airtable, dengan penjelasan bahwa antrean dan penerimaan data tetap manual.
- Menambahkan counter penggunaan agregat lokal tanpa URL, kode wilayah, asumsi, atau angka finansial; memperketat normalisasi state tersimpan.
- Mencatat baseline audit Meranti, Samosir, dan Bandung di `docs/audit-wilayah-2026-09.md`.
- Menyelaraskan `ROADMAP.md` dan `CHANGELOG.md`.

## Dampak versi

- [ ] `patch` — perbaikan bug/data tanpa fitur baru
- [x] `minor` — fitur baru yang tetap kompatibel
- [ ] `major` — perubahan yang memutus kompatibilitas
- [ ] Tidak mengubah versi — hanya dokumentasi, test, chore, atau CI

## Jika mengubah data

Tidak ada perubahan pada dataset yang di-ship. Dokumen audit hanya mencatat baseline dan keputusan sementara; semua kasus tetap `Pending`.

## Sebelum mengirim PR

- [x] `npm run typecheck` lulus
- [x] `npm test` lulus, termasuk pemeriksaan integritas data
- [x] `npm run build` lulus
- [x] Kalau mengubah logika di `src/lib/calculations.ts`, sudah menambah test
- [x] Tidak menambah dependency baru tanpa alasan di deskripsi ini

## QA dan risiko tersisa

- Verifikasi manual viewport 375px mencakup onboarding, legenda/filter, tema, drawer assumptions, focus trap, detail, CTA koreksi, mode relokasi, dan perbandingan dua kota tujuan.
- AP-04 masih membutuhkan operasi antrean/manual review nyata; AP-05 masih membutuhkan bukti lokal bertanggal sebelum perubahan data.